### PR TITLE
viewファイル等修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -54,3 +54,7 @@
 }
 // *送信ボタンの上部空白を作成するため
 
+.navigation-bar{
+  margin-left: 800px;
+}
+

--- a/app/controllers/buildings_controller.rb
+++ b/app/controllers/buildings_controller.rb
@@ -1,5 +1,9 @@
 class BuildingsController < ApplicationController
   def index
+    if user_signed_in?
+      render "home/index"
+    else
+      render "buildings/index"
+    end 
   end
-
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,2 +1,4 @@
 class HomeController < ApplicationController
+  def index
+  end
 end

--- a/app/views/buildings/index.html.erb
+++ b/app/views/buildings/index.html.erb
@@ -7,19 +7,28 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+      <% if user_signed_in? %>
+        <li class="nav-item nav-link navigation-bar">
+          <%= current_user.nickname%><%="さん"%>
+        </li>
         <li class="nav-item">
+          <%= link_to "ログアウト", destroy_user_session_path,method: :get, class:"nav-link"%>
+        </li>
+      <% else %>
+        <li class="nav-item navigation-bar">
           <a class="nav-link active" aria-current="page" href="#"></a>
         </li>
         <li class="nav-item">
           <%= link_to "ゲストログイン(閲覧用)", "#", class:"nav-link"%>
         </li>
         <li class="nav-item ">
-          <%= link_to "新規登録", new_user_registration_path,  class:"nav-link"%>
+          <%= link_to "新規登録", new_user_registration_path, class:"nav-link"%>
         </li>
         <li class="nav-item ">
-          <%= link_to "ログイン", user_session_path, class:"nav-link"%>
+          <%= link_to "ログイン", new_user_session_path, class:"nav-link"%>
         </li>
       </ul>
+      <% end %>
     </div>
   </div>
 </nav>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,13 +1,13 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
   <div class="container-fluid">
-    <%= link_to "Build Us", root_path, class:"navbar-brand" %>
+    <%= link_to "Build Us",home_index_path , class:"navbar-brand" %>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
       <% if user_signed_in? %>
-        <li class="nav-item nav-link">
+        <li class="nav-item nav-link navigation-bar">
           <%= current_user.nickname%><%="さん"%>
         </li>
         <li class="nav-item">


### PR DESCRIPTION
・ログイン前のナビゲーションバーに存在する「ゲストログイン」、「新規登録」、「ログイン」をページ左上から右上に変更。なおログイン後のnavバーも同様。
・不具合修正
＜修正前＞
ログイン後、新規登録後にnavnarの「Build Us」をクリックすることで "buildings/index"に遷移できてしまう。また、新規でブラウザを開いた際に、cookieの影響によりログインした状態で、"buildings/index"に遷移する
＜修正後＞
ログイン後、新規登録後にnavnarの「Build Us」をクリックすると"home/index"に留まる。また、新規でブラウザを開いた際に、cookieの影響によりログイン状態が保持された場合は、"home/index"に遷移する